### PR TITLE
Stop the memory leak in updating album image.

### DIFF
--- a/AirFloat.xcodeproj/project.pbxproj
+++ b/AirFloat.xcodeproj/project.pbxproj
@@ -938,6 +938,11 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0460;
+				TargetAttributes = {
+					4898F9ED13CDAAD1006EC97E = {
+						DevelopmentTeam = 2CK4GL5HTY;
+					};
+				};
 			};
 			buildConfigurationList = 4898F9E813CDAAD1006EC97E /* Build configuration list for PBXProject "AirFloat" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -1119,7 +1124,7 @@
 					armv6,
 					armv7,
 				);
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
@@ -1135,6 +1140,7 @@
 					"-DALLOW_LOCALHOST",
 					"-DUSE_BSD_SOCKETS",
 				);
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -1147,7 +1153,7 @@
 					armv6,
 					armv7,
 				);
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
@@ -1157,6 +1163,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				OTHER_CFLAGS = "-DUSE_BSD_SOCKETS";
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 			};
 			name = Release;
@@ -1169,6 +1176,7 @@
 					armv7,
 				);
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1201,6 +1209,7 @@
 					armv7,
 				);
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
@@ -1232,7 +1241,7 @@
 					armv6,
 					armv7,
 				);
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
@@ -1246,6 +1255,7 @@
 					"-DALLOW_LOCALHOST",
 					"-DUSE_BSD_SOCKETS",
 				);
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 			};
 			name = "Release (Server Logs)";
@@ -1258,6 +1268,7 @@
 					armv7,
 				);
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
@@ -1289,7 +1300,7 @@
 					armv6,
 					armv7,
 				);
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
@@ -1306,6 +1317,7 @@
 					"-DALLOW_LOCALHOST",
 					"-DUSE_BSD_SOCKETS",
 				);
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 			};
 			name = "Debug (Server Logs)";
@@ -1318,6 +1330,7 @@
 					armv7,
 				);
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1350,7 +1363,7 @@
 					armv6,
 					armv7,
 				);
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
@@ -1359,6 +1372,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 			};
 			name = "App Store Distribution";
@@ -1371,6 +1385,7 @@
 					armv7,
 				);
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
@@ -1402,7 +1417,7 @@
 					armv6,
 					armv7,
 				);
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
@@ -1411,6 +1426,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 			};
 			name = "Ad Hoc Distribution";
@@ -1423,6 +1439,7 @@
 					armv7,
 				);
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
@@ -1454,7 +1471,7 @@
 					armv6,
 					armv7,
 				);
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
@@ -1471,6 +1488,7 @@
 					"-DALAC_SOFTWARE",
 					"-DUSE_BSD_SOCKETS",
 				);
+				PROVISIONING_PROFILE = "";
 				SDKROOT = iphoneos;
 			};
 			name = "Debug (Server Logs - ALAC Software)";
@@ -1483,6 +1501,7 @@
 					armv7,
 				);
 				CLANG_ENABLE_OBJC_ARC = NO;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;

--- a/AirFloat/AirFloat-Info.plist
+++ b/AirFloat/AirFloat-Info.plist
@@ -43,7 +43,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4391</string>
+	<string>4442</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/AirFloat/AirFloatAppDelegate.m
+++ b/AirFloat/AirFloatAppDelegate.m
@@ -121,6 +121,13 @@
         
         struct raop_server_settings_t settings;
         settings.name = [[self.settings objectForKey:@"name"] cStringUsingEncoding:NSUTF8StringEncoding];
+        if (settings.name == nil) {
+            UIDevice *device=[UIDevice currentDevice];
+            NSString *name=[device name];
+            NSString *model=[device model];
+            
+            settings.name = [[NSString stringWithFormat:@"%@, %@", name, model] cStringUsingEncoding:NSUTF8StringEncoding];
+        }
         settings.password = ([[self.settings objectForKey:@"authenticationEnabled"] boolValue] ? [[self.settings objectForKey:@"password"] cStringUsingEncoding:NSUTF8StringEncoding] : NULL);
         
         self.server = raop_server_create(settings);

--- a/AirFloat/AppViewController.m
+++ b/AirFloat/AppViewController.m
@@ -571,13 +571,13 @@ void newServerSession(raop_server_p server, raop_session_p new_session, void* ct
                           MAX(screenSize.width, screenSize.height));
         
     }
+    [self.artworkImageView performSelectorOnMainThread:@selector(setImage:) withObject:image waitUntilDone:NO];
     
-    UIImage* actualImage = [image imageAspectedFilledWithSize:size];
-    UIImage* blurredImage = [actualImage imageGaussianBlurredWithRadius:10.0];
+    //UIImage* actualImage = [image imageAspectedFilledWithSize:size];
+    //UIImage* blurredImage = [actualImage imageGaussianBlurredWithRadius:10.0];
     
-    [self.artworkImageView performSelectorOnMainThread:@selector(setImage:) withObject:actualImage waitUntilDone:NO];
-    [self.blurredArtworkImageView performSelectorOnMainThread:@selector(setImage:) withObject:blurredImage waitUntilDone:NO];
-    
+    //[self.artworkImageView performSelectorOnMainThread:@selector(setImage:) withObject:actualImage waitUntilDone:NO];
+    //[self.blurredArtworkImageView performSelectorOnMainThread:@selector(setImage:) withObject:blurredImage waitUntilDone:NO];
 }
 
 - (void)clientUpdatedArtwork:(UIImage *)image {


### PR DESCRIPTION
It seems the images are not released while updating album image. The UIImage allocation are linear increasing in instrument while profiling. So I just use a awkward way to stop the memory leaking. Because I am not familiar with objc. Hope you could handle that better.

BTW, I remember my last patch to fix the data package time gap has introduced some new bugs. And this pull request also fix that too.