### PR TITLE
Fixes a memory management bug and adds some useful functions to libairfloat

### DIFF
--- a/libairfloat/libairfloat/dacpclient.c
+++ b/libairfloat/libairfloat/dacpclient.c
@@ -287,3 +287,28 @@ void dacp_client_previous(struct dacp_client_t* dc) {
     _dacp_client_send_request(dc, "previtem");
     
 }
+
+void dacp_client_stop(struct dacp_client_t* dc) {
+    
+    _dacp_client_send_request(dc, "stop");
+    
+}
+
+void dacp_client_seek(dacp_client_p dc, float seconds) {
+    
+    uint32_t milliseconds = seconds * 1000;
+    char cmd[100];
+    sprintf(cmd, "setproperty?dacp.playingtime=%d", milliseconds);
+    _dacp_client_send_request(dc, cmd);
+    
+}
+
+void dacp_client_set_volume(dacp_client_p dc, float volume) {
+    
+    if (volume >= 0 && volume <= 100.0) {
+        char cmd[100];
+        sprintf(cmd, "setproperty?dmcp.volume=%f", volume);
+        _dacp_client_send_request(dc, cmd);
+    }
+    
+}

--- a/libairfloat/libairfloat/dacpclient.h
+++ b/libairfloat/libairfloat/dacpclient.h
@@ -56,5 +56,8 @@ void dacp_client_update_playback_state(dacp_client_p dc);
 void dacp_client_next(dacp_client_p dc);
 void dacp_client_toggle_playback(dacp_client_p dc);
 void dacp_client_previous(dacp_client_p dc);
+void dacp_client_stop(dacp_client_p dc);
+void dacp_client_seek(dacp_client_p dc, float seconds);
+void dacp_client_set_volume(dacp_client_p dc, float volume);
 
 #endif

--- a/libairfloat/libairfloat/raopserver.c
+++ b/libairfloat/libairfloat/raopserver.c
@@ -257,3 +257,16 @@ void raop_server_session_ended(struct raop_server_t* rs, raop_session_p session)
     
     
 }
+
+void raop_server_set_volume(struct raop_server_t* rs, float volume) {
+    if (raop_server_is_recording(rs)) {
+        mutex_lock(rs->mutex);
+        uint32_t count = rs->sessions_count;
+        mutex_unlock(rs->mutex);
+        
+        for (uint32_t i = 0 ; i < count ; i++)
+            if (raop_session_is_recording(rs->sessions[i])) {
+                raop_session_set_volume(rs->sessions[i], volume);
+            }
+    }
+}

--- a/libairfloat/libairfloat/raopserver.c
+++ b/libairfloat/libairfloat/raopserver.c
@@ -167,7 +167,7 @@ struct raop_server_settings_t raop_server_get_settings(struct raop_server_t* rs)
 void raop_server_set_settings(struct raop_server_t* rs, struct raop_server_settings_t settings) {
     
     const char* old_name = settings_get_name(rs->settings);
-    char* old_name_c = (char*)malloc(strlen(settings_get_name(rs->settings) + 1));
+    char* old_name_c = (char*)malloc(strlen(old_name) + 1);
     strcpy(old_name_c, old_name);
     
     settings_set_name(rs->settings, settings.name);

--- a/libairfloat/libairfloat/raopserver.h
+++ b/libairfloat/libairfloat/raopserver.h
@@ -47,6 +47,7 @@ typedef struct raop_session_t *raop_session_p;
 #endif
 
 typedef void(*raop_server_new_session_callback)(raop_server_p server, raop_session_p new_session, void* ctx);
+typedef bool(*raop_server_accept_callback)(raop_server_p server, const char* connection_host, uint16_t connection_port, void* ctx);
 
 raop_server_p raop_server_create(struct raop_server_settings_t settings);
 void raop_server_destroy(raop_server_p rs);
@@ -57,5 +58,6 @@ struct raop_server_settings_t raop_server_get_settings(raop_server_p rs);
 void raop_server_set_settings(raop_server_p rs, struct raop_server_settings_t settings);
 void raop_server_stop(raop_server_p rs);
 void raop_server_set_new_session_callback(raop_server_p rs, raop_server_new_session_callback new_session_callback, void* ctx);
+void raop_server_set_session_accept_callback(raop_server_p rs, raop_server_accept_callback session_accept_callback, void* ctx);
 
 #endif

--- a/libairfloat/libairfloat/raopserver.h
+++ b/libairfloat/libairfloat/raopserver.h
@@ -56,6 +56,7 @@ bool raop_server_is_running(raop_server_p rs);
 bool raop_server_is_recording(raop_server_p rs);
 struct raop_server_settings_t raop_server_get_settings(raop_server_p rs);
 void raop_server_set_settings(raop_server_p rs, struct raop_server_settings_t settings);
+void raop_server_set_volume(raop_server_p rs, float volume);
 void raop_server_stop(raop_server_p rs);
 void raop_server_set_new_session_callback(raop_server_p rs, raop_server_new_session_callback new_session_callback, void* ctx);
 void raop_server_set_session_accept_callback(raop_server_p rs, raop_server_accept_callback session_accept_callback, void* ctx);

--- a/libairfloat/libairfloat/raopsession.h
+++ b/libairfloat/libairfloat/raopsession.h
@@ -46,6 +46,7 @@ typedef void(*raop_session_client_ended_recording_callback)(raop_session_p raop_
 typedef void(*raop_session_client_updated_track_info_callback)(raop_session_p raop_session, const char* title, const char* artist, const char* album, void* ctx);
 typedef void(*raop_session_client_updated_track_position_callback)(raop_session_p raop_session, double position, double total, void* ctx);
 typedef void(*raop_session_client_updated_artwork_callback)(raop_session_p raop_session, const void* data, size_t data_size, const char* mime_type, void* ctx);
+typedef void(*raop_session_client_updated_volume_callback)(raop_session_p raop_session, float volume, void* ctx);
 typedef void(*raop_session_ended_callback)(raop_session_p rs, void* ctx);
 
 struct raop_session_t* raop_session_create(raop_server_p server, web_server_connection_p connection, settings_p settings);
@@ -57,9 +58,12 @@ void raop_session_set_client_started_recording_callback(raop_session_p rs, raop_
 void raop_session_set_client_updated_track_info_callback(raop_session_p rs, raop_session_client_updated_track_info_callback callback, void* ctx);
 void raop_session_set_client_updated_track_position_callback(raop_session_p rs, raop_session_client_updated_track_position_callback callback, void* ctx);
 void raop_session_set_client_updated_artwork_callback(raop_session_p rs, raop_session_client_updated_artwork_callback callback, void* ctx);
+void raop_session_set_client_updated_volume_callback(raop_session_p rs, raop_session_client_updated_volume_callback callback, void* ctx);
 void raop_session_set_client_ended_recording_callback(raop_session_p rs, raop_session_client_ended_recording_callback callback, void* ctx);
 void raop_session_set_ended_callback(raop_session_p rs, raop_session_ended_callback callback, void* ctx);
 bool raop_session_is_recording(raop_session_p rs);
 dacp_client_p raop_session_get_dacp_client(raop_session_p rs);
+
+void raop_session_set_volume(struct raop_session_t* rs, float volume);
 
 #endif

--- a/libairfloat/libairfloat/rtprecorder.h
+++ b/libairfloat/libairfloat/rtprecorder.h
@@ -44,4 +44,7 @@ uint16_t rtp_recorder_get_streaming_port(rtp_recorder_p rr);
 uint16_t rtp_recorder_get_control_port(rtp_recorder_p rr);
 uint16_t rtp_recorder_get_timing_port(rtp_recorder_p rr);
 
+typedef void(*rtp_recorder_updated_track_position_callback)(rtp_recorder_p rr, unsigned int curr, void* ctx);
+void rtp_recorder_set_updated_track_position_callback(rtp_recorder_p rr, rtp_recorder_updated_track_position_callback callback, void* ctx);
+
 #endif

--- a/libairfloat/libairfloat/webserverconnection.c
+++ b/libairfloat/libairfloat/webserverconnection.c
@@ -215,3 +215,15 @@ struct sockaddr* web_server_connection_get_remote_end_point(struct web_server_co
     return socket_get_remote_end_point(wc->socket);
     
 }
+
+const char* web_server_connection_get_host(struct web_server_connection_t* wc) {
+    
+    return sockaddr_get_host(socket_get_remote_end_point(wc->socket));
+    
+}
+
+uint16_t web_server_connection_get_port(struct web_server_connection_t* wc) {
+    
+    return sockaddr_get_port(socket_get_remote_end_point(wc->socket));
+    
+}

--- a/libairfloat/libairfloat/webserverconnection.h
+++ b/libairfloat/libairfloat/webserverconnection.h
@@ -61,5 +61,7 @@ void web_server_connection_take_off(struct web_server_connection_t* wc);
 void web_server_connection_close(web_server_connection_p wc);
 struct sockaddr* web_server_connection_get_local_end_point(web_server_connection_p wc);
 struct sockaddr* web_server_connection_get_remote_end_point(web_server_connection_p wc);
+const char* web_server_connection_get_host(web_server_connection_p wc);
+uint16_t web_server_connection_get_port(web_server_connection_p wc);
 
 #endif


### PR DESCRIPTION
Fixes a memory management bug in libairfloat/raopserver.c that could lead to random crashes.
Fixes two issues when retrieving the current playback position:
- playback progress (the SET_PARAMETER request with a progress parameter) is only sent when the server starts playing a stream from the beginning or resumes stream delivery after pause
 (now sync packets are also used to retrieve the current playback position);
- the atoi function was used to convert the RTP timestamp string representation to integer, but the RTP timestamp value is of type unsigned integer. If the converted value would be out of the range of representable values by an int, it causes undefined behavior.

Adds the functions that allow to send commands to the AirPlay client to stop playback, seek in the track and set the volume level.
```
void dacp_client_stop(dacp_client_p dc);
void dacp_client_seek(dacp_client_p dc, float seconds);
void dacp_client_set_volume(dacp_client_p dc, float volume);
```

Adds the callback function that is invoked when the client changes the session volume level.
`typedef void(*raop_session_client_updated_volume_callback)(raop_session_p raop_session, float volume, void* ctx);`

Adds the function that allows to set the session volume level (the valid range is between 0.0 and 1.0).
`void raop_session_set_volume(struct raop_session_t* rs, float volume);`

Adds the callback function that allows to accept or reject a new connection to the RAOP server.
`typedef bool(*raop_server_accept_callback)(raop_server_p server, const char* connection_host, uint16_t connection_port, void* ctx);`
When a new connection is received, the provided callback function is invoked.
The second and the third arguments to the callback are the IP address and the port number of the remote host respectively.
To accept the connection, return true.
To reject the connect, return a value of false. This causes the connection object to be closed.