### PR TITLE
Added background keep-alive support. Added notifications. Increased Audio buffer (queue) size.

### DIFF
--- a/AirFloat.xcodeproj/project.pbxproj
+++ b/AirFloat.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		A129DD7D16F94D02004AA3BD /* SettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A129DD7C16F94D02004AA3BD /* SettingsViewController.m */; };
 		A12B7AFF14FDCBE20068538D /* AirFloatAdView.m in Sources */ = {isa = PBXBuildFile; fileRef = A12B7AFC14FDCBE20068538D /* AirFloatAdView.m */; };
 		A12B7B0914FDCCB20068538D /* Images.plist in Resources */ = {isa = PBXBuildFile; fileRef = A12B7B0514FDCCB20068538D /* Images.plist */; };
-		A12CB48A195047C00093C7AE /* libairfloat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A12CB487195047B30093C7AE /* libairfloat.a */; };
 		A1389E0914E417E6004FE040 /* TopBar.png in Resources */ = {isa = PBXBuildFile; fileRef = A1389E0714E417E6004FE040 /* TopBar.png */; };
 		A1389E0A14E417E6004FE040 /* TopBar@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A1389E0814E417E6004FE040 /* TopBar@2x.png */; };
 		A1389E0D14E41A87004FE040 /* NoArtwork~iphone.png in Resources */ = {isa = PBXBuildFile; fileRef = A1389E0B14E41A87004FE040 /* NoArtwork~iphone.png */; };
@@ -108,22 +107,23 @@
 		A1C7F79C1500D2B600D7DE52 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = A1C7F79B1500D2B600D7DE52 /* Default.png */; };
 		A1DE598714CF163500A6767D /* MediaPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1DE598614CF163500A6767D /* MediaPlayer.framework */; };
 		A1DF3AF514C4623700252C95 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1DF3AF414C4623700252C95 /* AVFoundation.framework */; };
+		C001F1F41CD888C1005954E3 /* liblibairfloat.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C001F1F01CD8880B005954E3 /* liblibairfloat.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		A12CB486195047B30093C7AE /* PBXContainerItemProxy */ = {
+		C001F1EF1CD8880B005954E3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A12CB482195047B30093C7AE /* libairfloat.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = A1D0DC501950378A004717F5;
-			remoteInfo = airfloat;
+			remoteInfo = libairfloat;
 		};
-		A12CB488195047BA0093C7AE /* PBXContainerItemProxy */ = {
+		C001F1F21CD888BC005954E3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = A12CB482195047B30093C7AE /* libairfloat.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = A1D0DC4F1950378A004717F5;
-			remoteInfo = airfloat;
+			remoteInfo = libairfloat;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -253,7 +253,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A12CB48A195047C00093C7AE /* libairfloat.a in Frameworks */,
+				C001F1F41CD888C1005954E3 /* liblibairfloat.a in Frameworks */,
 				A1ACB4F416FA286F008E4C4F /* OpenGLES.framework in Frameworks */,
 				A1ACB4EE16FA2264008E4C4F /* CoreImage.framework in Frameworks */,
 				A13F21C716ED10A900365A6D /* CFNetwork.framework in Frameworks */,
@@ -277,6 +277,7 @@
 			children = (
 				4898F9F813CDAAD1006EC97E /* AirFloat */,
 				4898F9EF13CDAAD1006EC97E /* Products */,
+				C001F23F1CD89645005954E3 /* libairfloat */,
 			);
 			sourceTree = "<group>";
 		};
@@ -291,7 +292,6 @@
 		4898F9F113CDAAD1006EC97E /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				A12CB482195047B30093C7AE /* libairfloat.xcodeproj */,
 				A17E9233152DA909000331D3 /* libz.1.tbd */,
 				A1ACB4F316FA286F008E4C4F /* OpenGLES.framework */,
 				A1ACB4ED16FA2264008E4C4F /* CoreImage.framework */,
@@ -313,9 +313,11 @@
 		4898F9F813CDAAD1006EC97E /* AirFloat */ = {
 			isa = PBXGroup;
 			children = (
-				A1B3E3DE14CE09A300379E8C /* Additions */,
-				A116EA8B16EE6278005530E9 /* App */,
+				4898FA0113CDAAD1006EC97E /* AirFloatAppDelegate.h */,
+				4898FA0213CDAAD1006EC97E /* AirFloatAppDelegate.m */,
+				A116EA8B16EE6278005530E9 /* Source */,
 				4898F9F913CDAAD1006EC97E /* Supporting Files */,
+				A1B3E3DE14CE09A300379E8C /* Additions */,
 				4898F9F113CDAAD1006EC97E /* Frameworks */,
 			);
 			path = AirFloat;
@@ -331,43 +333,43 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		A116EA8B16EE6278005530E9 /* App */ = {
+		A116EA8B16EE6278005530E9 /* Source */ = {
 			isa = PBXGroup;
 			children = (
 				A116EA8F16EE629C005530E9 /* View Controllers */,
-				4898FA0113CDAAD1006EC97E /* AirFloatAppDelegate.h */,
-				4898FA0213CDAAD1006EC97E /* AirFloatAppDelegate.m */,
+				A1594D9916FCB22900D14269 /* Controls */,
+				A12B7AF914FDCBCE0068538D /* Views */,
+				A1ACB4EF16FA2345008E4C4F /* Categories */,
 			);
-			name = App;
+			name = Source;
 			sourceTree = "<group>";
 		};
 		A116EA8F16EE629C005530E9 /* View Controllers */ = {
 			isa = PBXGroup;
 			children = (
-				A176B6F817385FD900024A3D /* Panels */,
 				A116EA8C16EE6297005530E9 /* AppViewController.h */,
 				A116EA8D16EE6297005530E9 /* AppViewController.m */,
+				A146A93516FA625600698A49 /* SupportViewController.h */,
+				A146A93616FA625600698A49 /* SupportViewController.m */,
+				A129DD7B16F94D02004AA3BD /* SettingsViewController.h */,
+				A129DD7C16F94D02004AA3BD /* SettingsViewController.m */,
+				A176B6F517385FD600024A3D /* PanelViewController.h */,
+				A176B6F617385FD600024A3D /* PanelViewController.m */,
 			);
 			name = "View Controllers";
 			sourceTree = "<group>";
 		};
-		A12B7AF914FDCBCE0068538D /* Intro */ = {
+		A12B7AF914FDCBCE0068538D /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				A129DD6116F93586004AA3BD /* AirFloatReflectionView.h */,
+				A129DD6216F93586004AA3BD /* AirFloatReflectionView.m */,
 				A116EA8416EE448D005530E9 /* AirFloatFlipInView.h */,
 				A116EA8516EE448D005530E9 /* AirFloatFlipInView.m */,
 				A12B7AFB14FDCBE20068538D /* AirFloatAdView.h */,
 				A12B7AFC14FDCBE20068538D /* AirFloatAdView.m */,
 			);
-			name = Intro;
-			sourceTree = "<group>";
-		};
-		A12CB483195047B30093C7AE /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				A12CB487195047B30093C7AE /* libairfloat.a */,
-			);
-			name = Products;
+			name = Views;
 			sourceTree = "<group>";
 		};
 		A146A93216FA5C0300698A49 /* Support */ = {
@@ -385,8 +387,12 @@
 		A1594D9916FCB22900D14269 /* Controls */ = {
 			isa = PBXGroup;
 			children = (
+				A10392D814E9B6C400DB356F /* AirFloatBarButton.h */,
+				A10392D914E9B6C400DB356F /* AirFloatBarButton.m */,
 				A1594D9A16FCB24100D14269 /* AirFloatSwitch.h */,
 				A1594D9B16FCB24100D14269 /* AirFloatSwitch.m */,
+				A174B37616FB0F4C0063035C /* AirFloatScrollingLabel.h */,
+				A174B37716FB0F4C0063035C /* AirFloatScrollingLabel.m */,
 			);
 			name = Controls;
 			sourceTree = "<group>";
@@ -408,20 +414,6 @@
 			name = Switch;
 			sourceTree = "<group>";
 		};
-		A16EF34514FB79C800593466 /* Cocoa Touch */ = {
-			isa = PBXGroup;
-			children = (
-				A12B7AF914FDCBCE0068538D /* Intro */,
-				A10392D814E9B6C400DB356F /* AirFloatBarButton.h */,
-				A10392D914E9B6C400DB356F /* AirFloatBarButton.m */,
-				A129DD6116F93586004AA3BD /* AirFloatReflectionView.h */,
-				A129DD6216F93586004AA3BD /* AirFloatReflectionView.m */,
-				A174B37616FB0F4C0063035C /* AirFloatScrollingLabel.h */,
-				A174B37716FB0F4C0063035C /* AirFloatScrollingLabel.m */,
-			);
-			name = "Cocoa Touch";
-			sourceTree = "<group>";
-		};
 		A174B37D16FC70F20063035C /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -434,36 +426,6 @@
 				A1594DB316FD231800D14269 /* SettingsInputHighlightedBackground@2x.png */,
 				A174B37E16FC71050063035C /* SettingsGroupBackground.png */,
 				A174B37F16FC71050063035C /* SettingsGroupBackground@2x.png */,
-			);
-			name = Settings;
-			sourceTree = "<group>";
-		};
-		A176B6F817385FD900024A3D /* Panels */ = {
-			isa = PBXGroup;
-			children = (
-				A176B6F917385FE100024A3D /* Support */,
-				A176B6FA17385FE600024A3D /* Settings */,
-				A176B6F517385FD600024A3D /* PanelViewController.h */,
-				A176B6F617385FD600024A3D /* PanelViewController.m */,
-			);
-			name = Panels;
-			sourceTree = "<group>";
-		};
-		A176B6F917385FE100024A3D /* Support */ = {
-			isa = PBXGroup;
-			children = (
-				A146A93516FA625600698A49 /* SupportViewController.h */,
-				A146A93616FA625600698A49 /* SupportViewController.m */,
-			);
-			name = Support;
-			sourceTree = "<group>";
-		};
-		A176B6FA17385FE600024A3D /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				A1594D9916FCB22900D14269 /* Controls */,
-				A129DD7B16F94D02004AA3BD /* SettingsViewController.h */,
-				A129DD7C16F94D02004AA3BD /* SettingsViewController.m */,
 			);
 			name = Settings;
 			sourceTree = "<group>";
@@ -585,15 +547,6 @@
 			name = Other;
 			sourceTree = "<group>";
 		};
-		A1A8079614F10FB5005FFDA5 /* Custom Classes */ = {
-			isa = PBXGroup;
-			children = (
-				A1ACB4EF16FA2345008E4C4F /* Categories */,
-				A16EF34514FB79C800593466 /* Cocoa Touch */,
-			);
-			name = "Custom Classes";
-			sourceTree = "<group>";
-		};
 		A1ACB4EF16FA2345008E4C4F /* Categories */ = {
 			isa = PBXGroup;
 			children = (
@@ -608,9 +561,24 @@
 		A1B3E3DE14CE09A300379E8C /* Additions */ = {
 			isa = PBXGroup;
 			children = (
-				A1A8079614F10FB5005FFDA5 /* Custom Classes */,
 			);
 			name = Additions;
+			sourceTree = "<group>";
+		};
+		C001F1EC1CD8880B005954E3 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C001F1F01CD8880B005954E3 /* liblibairfloat.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		C001F23F1CD89645005954E3 /* libairfloat */ = {
+			isa = PBXGroup;
+			children = (
+				A12CB482195047B30093C7AE /* libairfloat.xcodeproj */,
+			);
+			name = libairfloat;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -628,7 +596,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				A12CB489195047BA0093C7AE /* PBXTargetDependency */,
+				C001F1F31CD888BC005954E3 /* PBXTargetDependency */,
 			);
 			name = AirFloat;
 			productName = AirFloat;
@@ -641,12 +609,7 @@
 		4898F9E513CDAAD1006EC97E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
-				TargetAttributes = {
-					4898F9ED13CDAAD1006EC97E = {
-						DevelopmentTeam = 62L85VT9WB;
-					};
-				};
+				LastUpgradeCheck = 0730;
 			};
 			buildConfigurationList = 4898F9E813CDAAD1006EC97E /* Build configuration list for PBXProject "AirFloat" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -654,13 +617,14 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 4898F9E313CDAAD1006EC97E;
 			productRefGroup = 4898F9EF13CDAAD1006EC97E /* Products */;
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = A12CB483195047B30093C7AE /* Products */;
+					ProductGroup = C001F1EC1CD8880B005954E3 /* Products */;
 					ProjectRef = A12CB482195047B30093C7AE /* libairfloat.xcodeproj */;
 				},
 			);
@@ -672,11 +636,11 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		A12CB487195047B30093C7AE /* libairfloat.a */ = {
+		C001F1F01CD8880B005954E3 /* liblibairfloat.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = libairfloat.a;
-			remoteRef = A12CB486195047B30093C7AE /* PBXContainerItemProxy */;
+			path = liblibairfloat.a;
+			remoteRef = C001F1EF1CD8880B005954E3 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -806,10 +770,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		A12CB489195047BA0093C7AE /* PBXTargetDependency */ = {
+		C001F1F31CD888BC005954E3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = airfloat;
-			targetProxy = A12CB488195047BA0093C7AE /* PBXContainerItemProxy */;
+			name = libairfloat;
+			targetProxy = C001F1F21CD888BC005954E3 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -818,17 +782,21 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = armv7;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
@@ -836,7 +804,14 @@
 					"-DALLOW_LOCALHOST",
 					"-DUSE_BSD_SOCKETS",
 				);
+				OTHER_LDFLAGS = (
+					"-all_load",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.tren.AirFloat;
+				PRODUCT_NAME = "";
 				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -844,49 +819,41 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = armv7;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_THUMB_SUPPORT = NO;
-				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-DUSE_BSD_SOCKETS";
-				SDKROOT = iphoneos;
-			};
-			name = Release;
-		};
-		4898FA1013CDAAD1006EC97E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
 				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/..\"",
 					"\"$(SRCROOT)\"",
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-DUSE_BSD_SOCKETS";
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-ObjC",
 				);
-				PRODUCT_NAME = AirFloat;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tren.AirFloat;
+				PRODUCT_NAME = "";
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4898FA1013CDAAD1006EC97E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
+				PRODUCT_NAME = AirFloat;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -894,30 +861,8 @@
 		4898FA1113CDAAD1006EC97E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
-				GCC_THUMB_SUPPORT = NO;
-				GCC_VERSION = "";
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
 				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/..\"",
-					"\"$(SRCROOT)\"",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-all_load",
-					"-ObjC",
-				);
 				PRODUCT_NAME = AirFloat;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
@@ -926,53 +871,46 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = armv7;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_THUMB_SUPPORT = NO;
-				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-DLOG_SERVER",
-					"-DALLOW_LOCALHOST",
-					"-DUSE_BSD_SOCKETS",
-				);
-				SDKROOT = iphoneos;
-			};
-			name = "Release (Server Logs)";
-		};
-		A116EA6516EDFDC7005530E9 /* Release (Server Logs) */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
-				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/..\"",
 					"\"$(SRCROOT)\"",
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-DLOG_SERVER",
+					"-DALLOW_LOCALHOST",
+					"-DUSE_BSD_SOCKETS",
+				);
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-ObjC",
 				);
-				PRODUCT_NAME = AirFloat;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tren.AirFloat;
+				PRODUCT_NAME = "";
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
+			};
+			name = "Release (Server Logs)";
+		};
+		A116EA6516EDFDC7005530E9 /* Release (Server Logs) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
+				PRODUCT_NAME = AirFloat;
 				WRAPPER_EXTENSION = app;
 			};
 			name = "Release (Server Logs)";
@@ -981,18 +919,26 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = armv7;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/..\"",
+					"\"$(SRCROOT)\"",
+				);
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-DDEBUG",
@@ -1000,37 +946,23 @@
 					"-DALLOW_LOCALHOST",
 					"-DUSE_BSD_SOCKETS",
 				);
+				OTHER_LDFLAGS = (
+					"-all_load",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.tren.AirFloat;
+				PRODUCT_NAME = "";
 				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = "Debug (Server Logs)";
 		};
 		A149209514E7323900849DC3 /* Debug (Server Logs) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
-				GCC_THUMB_SUPPORT = NO;
-				GCC_VERSION = "";
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
 				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/..\"",
-					"\"$(SRCROOT)\"",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-all_load",
-					"-ObjC",
-				);
 				PRODUCT_NAME = AirFloat;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = "Debug (Server Logs)";
@@ -1039,35 +971,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = armv7;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_THUMB_SUPPORT = NO;
-				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-			};
-			name = "App Store Distribution";
-		};
-		A1A76012151B56B800728C9C /* App Store Distribution */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
-				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/..\"",
@@ -1078,9 +994,19 @@
 					"-all_load",
 					"-ObjC",
 				);
-				PRODUCT_NAME = AirFloat;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tren.AirFloat;
+				PRODUCT_NAME = "";
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+			};
+			name = "App Store Distribution";
+		};
+		A1A76012151B56B800728C9C /* App Store Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
+				PRODUCT_NAME = AirFloat;
 				WRAPPER_EXTENSION = app;
 			};
 			name = "App Store Distribution";
@@ -1089,35 +1015,19 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = armv7;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_THUMB_SUPPORT = NO;
-				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-			};
-			name = "Ad Hoc Distribution";
-		};
-		A1C7F7AB1501048400D7DE52 /* Ad Hoc Distribution */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
-				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/..\"",
@@ -1128,9 +1038,19 @@
 					"-all_load",
 					"-ObjC",
 				);
-				PRODUCT_NAME = AirFloat;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tren.AirFloat;
+				PRODUCT_NAME = "";
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+			};
+			name = "Ad Hoc Distribution";
+		};
+		A1C7F7AB1501048400D7DE52 /* Ad Hoc Distribution */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
+				PRODUCT_NAME = AirFloat;
 				WRAPPER_EXTENSION = app;
 			};
 			name = "Ad Hoc Distribution";
@@ -1139,56 +1059,50 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				CODE_SIGN_IDENTITY = "";
+				ARCHS = armv7;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_THUMB_SUPPORT = NO;
-				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
-				MACOSX_DEPLOYMENT_TARGET = 10.8;
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-DDEBUG",
-					"-DLOG_SERVER",
-					"-DALAC_SOFTWARE",
-					"-DUSE_BSD_SOCKETS",
-				);
-				SDKROOT = iphoneos;
-			};
-			name = "Debug (Server Logs - ALAC Software)";
-		};
-		A1ECED9016E8CFA500F8E7E3 /* Debug (Server Logs - ALAC Software) */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				ENABLE_BITCODE = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "AirFloat/AirFloat-Prefix.pch";
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/libairfloat\"";
-				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.1.1;
+				INFOPLIST_FILE = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/..\"",
 					"\"$(SRCROOT)\"",
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-DDEBUG",
+					"-DLOG_SERVER",
+					"-DALAC_SOFTWARE",
+					"-DUSE_BSD_SOCKETS",
+					"-LOG_SERVER",
+				);
 				OTHER_LDFLAGS = (
 					"-all_load",
 					"-ObjC",
 				);
-				PRODUCT_NAME = AirFloat;
+				PRODUCT_BUNDLE_IDENTIFIER = com.tren.AirFloat;
+				PRODUCT_NAME = "";
+				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Debug (Server Logs - ALAC Software)";
+		};
+		A1ECED9016E8CFA500F8E7E3 /* Debug (Server Logs - ALAC Software) */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "AirFloat/AirFloat-Info.plist";
+				PRODUCT_NAME = AirFloat;
 				WRAPPER_EXTENSION = app;
 			};
 			name = "Debug (Server Logs - ALAC Software)";

--- a/AirFloat/AirFloat-Info.plist
+++ b/AirFloat/AirFloat-Info.plist
@@ -31,7 +31,7 @@
 		</dict>
 	</dict>
 	<key>CFBundleIdentifier</key>
-	<string>com.tren.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -43,7 +43,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>4479</string>
+	<string>4596</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>LSRequiresIPhoneOS</key>
@@ -63,6 +63,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/AirFloat/AirFloatAppDelegate.h
+++ b/AirFloat/AirFloatAppDelegate.h
@@ -39,5 +39,6 @@
 @property (nonatomic, strong) AppViewController* appViewController;
 - (NSDictionary*) getSettings;
 - (void) setSettings:(NSDictionary *)settings;
+- (void) startRaopServer;
 
 @end

--- a/AirFloat/AirFloatAppDelegate.h
+++ b/AirFloat/AirFloatAppDelegate.h
@@ -29,23 +29,14 @@
 //
 
 #import <UIKit/UIKit.h>
-
 #import "AppViewController.h"
-
-#import <libairfloat/raopserver.h>
 
 #define AirFloatSharedAppDelegate ((AirFloatAppDelegate*)[UIApplication sharedApplication].delegate)
 
-@interface AirFloatAppDelegate : NSObject <UIApplicationDelegate> {
-    
-    raop_server_p _server;
-    UIBackgroundTaskIdentifier _backgroundTask;
-    
-}
+@interface AirFloatAppDelegate : NSObject <UIApplicationDelegate> 
 
 @property (nonatomic, strong) UIWindow *window;
 @property (nonatomic, strong) AppViewController* appViewController;
-@property (nonatomic, assign) raop_server_p server;
-@property (nonatomic, strong) NSDictionary* settings;
+
 
 @end

--- a/AirFloat/AirFloatAppDelegate.h
+++ b/AirFloat/AirFloatAppDelegate.h
@@ -40,5 +40,6 @@
 - (NSDictionary*) getSettings;
 - (void) setSettings:(NSDictionary *)settings;
 - (void) startRaopServer;
+- (void) showNotification:(NSString*)messageTitle;
 
 @end

--- a/AirFloat/AirFloatAppDelegate.h
+++ b/AirFloat/AirFloatAppDelegate.h
@@ -37,6 +37,7 @@
 
 @property (nonatomic, strong) UIWindow *window;
 @property (nonatomic, strong) AppViewController* appViewController;
-
+- (NSDictionary*) getSettings;
+- (void) setSettings:(NSDictionary *)settings;
 
 @end

--- a/AirFloat/AirFloatAppDelegate.m
+++ b/AirFloat/AirFloatAppDelegate.m
@@ -46,17 +46,11 @@
     NSDictionary *_settings;
 }
 
+#pragma mark - Application Settings
+
 - (NSString *)settingsPath {
-
+    
     NSString* filename = [[[NSBundle mainBundle] bundleIdentifier] stringByAppendingPathExtension:@"plist"];
-
-//#if TARGET_IPHONE_SIMULATOR
-    //NSString* path = [[NSString stringWithFormat:@"/Users/%@/Library/Preferences/", NSUserName()] stringByAppendingPathComponent:filename];
-//#else
-    //NSString* path = [@"/var/mobile/Library/Preferences/" stringByAppendingPathComponent:filename];
-//#endif
-
-    //return path;
     NSArray *mypaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDirectory = [mypaths objectAtIndex:0];
     NSString *newpath = [documentsDirectory stringByAppendingPathComponent:filename];
@@ -64,7 +58,7 @@
     return newpath;
 }
 
-- (NSDictionary *)settings {
+- (NSDictionary *)getSettings {
     
     if (!_settings) {
         _settings = [[NSDictionary alloc] initWithContentsOfFile:[self settingsPath]];
@@ -94,7 +88,7 @@
     }
     
     [self didChangeValueForKey:@"settings"];
-        
+    
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
@@ -121,8 +115,8 @@
     if (!self.server) {
         
         struct raop_server_settings_t settings;
-        settings.name = [[self.settings objectForKey:@"name"] cStringUsingEncoding:NSUTF8StringEncoding];
-        settings.password = ([[self.settings objectForKey:@"authenticationEnabled"] boolValue] ? [[self.settings objectForKey:@"password"] cStringUsingEncoding:NSUTF8StringEncoding] : NULL);
+        settings.name = [[_settings objectForKey:@"name"] cStringUsingEncoding:NSUTF8StringEncoding];
+        settings.password = ([[_settings objectForKey:@"authenticationEnabled"] boolValue] ? [[_settings objectForKey:@"password"] cStringUsingEncoding:NSUTF8StringEncoding] : NULL);
         
         self.server = raop_server_create(settings);
         

--- a/AirFloat/AirFloatAppDelegate.m
+++ b/AirFloat/AirFloatAppDelegate.m
@@ -84,14 +84,9 @@
     [self.appViewController handleForegroundTasks];
 }
 
-- (void)applicationDidEnterBackground:(UIApplication *)application {
-    
-    if (self.server && !raop_server_is_recording(self.server)) {
-        raop_server_stop(self.server);
-        raop_server_destroy(self.server);
-        self.appViewController.server = self.server = NULL;
-    }
-    
+- (void)applicationDidEnterBackground:(UIApplication *)application
+{
+    [self.appViewController handleBackgroundTasks];
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application

--- a/AirFloat/AirFloatAppDelegate.m
+++ b/AirFloat/AirFloatAppDelegate.m
@@ -35,30 +35,27 @@
 
 #import "AirFloatAppDelegate.h"
 
-@interface AirFloatAppDelegate () {
-    
-    NSDictionary* _settings;
-    
-}
+@interface AirFloatAppDelegate ()
+
+@property (nonatomic, assign) raop_server_p server;
 
 @end
-
-@implementation AirFloatAppDelegate
-
-@synthesize window=_window;
-@synthesize appViewController=_appViewController;
-@synthesize server=_server;
+    
+@implementation AirFloatAppDelegate {
+    UIBackgroundTaskIdentifier *_backgroundTask;
+    NSDictionary *_settings;
+}
 
 - (NSString *)settingsPath {
-    
+
     NSString* filename = [[[NSBundle mainBundle] bundleIdentifier] stringByAppendingPathExtension:@"plist"];
-    
+
 //#if TARGET_IPHONE_SIMULATOR
     //NSString* path = [[NSString stringWithFormat:@"/Users/%@/Library/Preferences/", NSUserName()] stringByAppendingPathComponent:filename];
 //#else
     //NSString* path = [@"/var/mobile/Library/Preferences/" stringByAppendingPathComponent:filename];
 //#endif
-    
+
     //return path;
     NSArray *mypaths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDirectory = [mypaths objectAtIndex:0];
@@ -101,9 +98,9 @@
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    
+
     self.appViewController = [[[AppViewController alloc] init] autorelease];
-    
+
     self.window = [[[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds] autorelease];
     
     if ([self.window respondsToSelector:@selector(setRootViewController:)])

--- a/AirFloat/AppViewController.h
+++ b/AirFloat/AppViewController.h
@@ -29,11 +29,12 @@
 //
 
 #import <UIKit/UIKit.h>
-
 #import <libairfloat/raopserver.h>
 
 @interface AppViewController : UIViewController
 
 @property (assign,nonatomic,readwrite) raop_server_p server;
+- (void)handleForegroundTasks;
+- (void)handleBackgroundTasks;
 
 @end

--- a/AirFloat/AppViewController.m
+++ b/AirFloat/AppViewController.m
@@ -733,11 +733,11 @@ void newServerSession(raop_server_p server, raop_session_p new_session, void* ct
 
 - (void)updateScreenIdleState {
     
-    BOOL disabled = [[AirFloatSharedAppDelegate.settings objectForKey:@"keepScreenLit"] boolValue];
+    BOOL disabled = [[[AirFloatSharedAppDelegate getSettings] objectForKey:@"keepScreenLit"] boolValue];
     
-    disabled &= (![[AirFloatSharedAppDelegate.settings objectForKey:@"keepScreenLitOnlyWhenReceiving"] boolValue] || (_server != NULL && raop_server_is_recording(_server)));
+    disabled &= (![[[AirFloatSharedAppDelegate getSettings] objectForKey:@"keepScreenLitOnlyWhenReceiving"] boolValue] || (_server != NULL && raop_server_is_recording(_server)));
     
-    disabled &= (![[AirFloatSharedAppDelegate.settings objectForKey:@"keepScreenLitOnlyWhenConnectedToPower"] boolValue] || ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateCharging || [UIDevice currentDevice].batteryState == UIDeviceBatteryStateFull));
+    disabled &= (![[[AirFloatSharedAppDelegate getSettings] objectForKey:@"keepScreenLitOnlyWhenConnectedToPower"] boolValue] || ([UIDevice currentDevice].batteryState == UIDeviceBatteryStateCharging || [UIDevice currentDevice].batteryState == UIDeviceBatteryStateFull));
     
     [UIApplication sharedApplication].idleTimerDisabled = disabled;
     

--- a/AirFloat/AppViewController.m
+++ b/AirFloat/AppViewController.m
@@ -778,13 +778,11 @@ dispatch_block_t helperBackgroundTaskBlock = ^{
 
 -(void) handleBackgroundTasks {
     UIDevice *device = [UIDevice currentDevice];
-    BOOL playing = (dacp_client_get_playback_state(_dacp_client) == dacp_client_playback_state_playing);
     BOOL backgroundSupported = NO;
     if ([device respondsToSelector:@selector(isMultitaskingSupported)]) {
         backgroundSupported = device.multitaskingSupported;
     }
-    
-    if(backgroundSupported && !playing) { // perform a background task
+    if(backgroundSupported) { // perform a background task
         
         helperBackgroundTaskBlock = ^{
             [[UIApplication sharedApplication] endBackgroundTask: helperBackgroundTask];
@@ -827,5 +825,6 @@ dispatch_block_t helperBackgroundTaskBlock = ^{
 
 -(void) keepAlive {
     [AirFloatSharedAppDelegate startRaopServer];
+    NSLog(@"keepAlive");
 }
 @end

--- a/AirFloat/AppViewController.m
+++ b/AirFloat/AppViewController.m
@@ -29,13 +29,10 @@
 //
 
 #import <MediaPlayer/MediaPlayer.h>
-
 #import <libairfloat/webserverconnection.h>
 #import <libairfloat/dacpclient.h>
 #import <libairfloat/raopsession.h>
-
 #import "UIImage+AirFloatAdditions.h"
-
 #import "AirFloatAppDelegate.h"
 #import "AirFloatAdView.h"
 #import "SupportViewController.h"
@@ -78,6 +75,7 @@
 @end
 
 UIBackgroundTaskIdentifier backgroundTask = 0;
+UIBackgroundTaskIdentifier helperBackgroundTask = 0;
 
 void dacpClientControlsBecameAvailable(dacp_client_p client, void* ctx) {
     
@@ -131,8 +129,9 @@ void clientEndedRecording(raop_session_p raop_session, void* ctx) {
     
     AppViewController* viewController = (AppViewController*)ctx;
     
-    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground)
+    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
         backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:nil];
+    }
     
     [viewController performSelectorOnMainThread:@selector(clientEndedRecording) withObject:nil waitUntilDone:NO];
     
@@ -141,6 +140,10 @@ void clientEndedRecording(raop_session_p raop_session, void* ctx) {
 void clientEnded(raop_session_p raop_session, void* ctx) {
     
     AppViewController* viewController = (AppViewController*)ctx;
+    
+    if ([UIApplication sharedApplication].applicationState == UIApplicationStateBackground) {
+        [AirFloatSharedAppDelegate showNotification:@"Client disconnected."];
+    }
     
     [viewController performSelectorOnMainThread:@selector(clientEnded) withObject:nil waitUntilDone:NO];
     
@@ -188,7 +191,7 @@ void clientUpdatedTrackInfo(raop_session_p raop_session, const char* title, cons
     
     [trackTitle release];
     [artistTitle release];
-        
+    
     [pool release];
     
 }
@@ -457,7 +460,7 @@ void newServerSession(raop_server_p server, raop_session_p new_session, void* ct
                 
                 if (_artworkImage)
                     [nowPlayingInfo setObject:[[[MPMediaItemArtwork alloc] initWithImage:_artworkImage] autorelease]
-                                   forKey:MPMediaItemPropertyArtwork];
+                                       forKey:MPMediaItemPropertyArtwork];
                 
                 [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = nowPlayingInfo;
                 
@@ -752,7 +755,77 @@ void newServerSession(raop_server_p server, raop_session_p new_session, void* ct
 - (void)batteryStateChanged:(NSNotification *)notification {
     
     [self updateScreenIdleState];
-    
 }
 
+
+#pragma mark - Workaround for iOS Background Mode restrictions
+
+dispatch_block_t helperBackgroundTaskBlock = ^{
+    [[UIApplication sharedApplication] endBackgroundTask:helperBackgroundTask];
+    helperBackgroundTask = UIBackgroundTaskInvalid;
+    helperBackgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:helperBackgroundTaskBlock];
+};
+
+
+#pragma mark - Handler for background/foreground state switch
+
+-(void)handleForegroundTasks {
+    if(helperBackgroundTask) { // reset that task
+        [[UIApplication sharedApplication] endBackgroundTask: helperBackgroundTask];
+        helperBackgroundTask = UIBackgroundTaskInvalid;
+    }
+}
+
+-(void) handleBackgroundTasks {
+    UIDevice *device = [UIDevice currentDevice];
+    BOOL playing = (dacp_client_get_playback_state(_dacp_client) == dacp_client_playback_state_playing);
+    BOOL backgroundSupported = NO;
+    if ([device respondsToSelector:@selector(isMultitaskingSupported)]) {
+        backgroundSupported = device.multitaskingSupported;
+    }
+    
+    if(backgroundSupported && !playing) { // perform a background task
+        
+        helperBackgroundTaskBlock = ^{
+            [[UIApplication sharedApplication] endBackgroundTask: helperBackgroundTask];
+            helperBackgroundTask = UIBackgroundTaskInvalid;
+        };
+        
+        [self doBackgroundTaskAsync:@selector(keepAlive)];
+        [self performSelector:@selector(doBackgroundTaskAsync:) withObject:nil afterDelay:170.0f];
+    }
+}
+
+-(void) doBackgroundTaskAsync:(SEL)selector {
+    
+    if( [[UIApplication sharedApplication] backgroundTimeRemaining] < 5 ) {
+        return;
+    }
+    
+    if(!helperBackgroundTaskBlock) {
+        helperBackgroundTaskBlock = ^{
+            [[UIApplication sharedApplication] endBackgroundTask:helperBackgroundTask];
+            helperBackgroundTask = UIBackgroundTaskInvalid;
+        };
+    }
+    
+    helperBackgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:helperBackgroundTaskBlock];
+    
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+        
+        while ([[UIApplication sharedApplication] backgroundTimeRemaining] > 5.0) {
+            int delta = 5.0;
+            [self performSelector: @selector(keepAlive)];
+            
+            sleep(delta);
+        }
+    });
+}
+
+
+#pragma mark - Restarts RAOP instance when needed
+
+-(void) keepAlive {
+    [AirFloatSharedAppDelegate startRaopServer];
+}
 @end

--- a/AirFloat/SettingsViewController.m
+++ b/AirFloat/SettingsViewController.m
@@ -63,7 +63,7 @@ NSString *const SettingsUpdatedNotification = @"SettingsUpdatedNotification";
     
     ((UIScrollView*)self.view).contentSize = CGSizeMake(320, 358);
     
-    NSDictionary* settings = AirFloatSharedAppDelegate.settings;
+    NSDictionary* settings = [AirFloatSharedAppDelegate getSettings];
     
     self.nameField.text = [settings objectForKey:@"name"];
     self.authenticationField.text = [settings objectForKey:@"password"];
@@ -144,7 +144,7 @@ NSString *const SettingsUpdatedNotification = @"SettingsUpdatedNotification";
         
     }
     
-    AirFloatSharedAppDelegate.settings = settings;
+    [AirFloatSharedAppDelegate setSettings: settings];
     
     [self updateVisuals:settings];
     

--- a/libairfloat/libairfloat.xcodeproj/project.pbxproj
+++ b/libairfloat/libairfloat.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 		A1D0DC88195037EE004717F5 /* thread_posix.c in Sources */ = {isa = PBXBuildFile; fileRef = A14583AA16DAE43400911FE6 /* thread_posix.c */; };
 		A1D0DC89195037FD004717F5 /* alac.c in Sources */ = {isa = PBXBuildFile; fileRef = A19E4B0C16CA95AC00E5D60F /* alac.c */; };
 		A1D0DC8A195037FD004717F5 /* alac_format.c in Sources */ = {isa = PBXBuildFile; fileRef = A1E9741116DBB24D000AD9E4 /* alac_format.c */; };
-		A1D0DC8B195037FD004717F5 /* decoder_alac_apple.c in Sources */ = {isa = PBXBuildFile; fileRef = A1E9740C16DBAE9B000AD9E4 /* decoder_alac_apple.c */; };
 		A1D0DC8C195037FD004717F5 /* decoder.c in Sources */ = {isa = PBXBuildFile; fileRef = A1E9740816DBAE79000AD9E4 /* decoder.c */; };
 		A1D0DC8D19503824004717F5 /* audiooutput_apple.m in Sources */ = {isa = PBXBuildFile; fileRef = A19E4AF216CA959700E5D60F /* audiooutput_apple.m */; };
 		A1D0DC8E19503826004717F5 /* audioqueue.c in Sources */ = {isa = PBXBuildFile; fileRef = A19E4AF616CA959700E5D60F /* audioqueue.c */; };
@@ -44,17 +43,19 @@
 		A1D0DCA719503F89004717F5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4898F9F213CDAAD1006EC97E /* UIKit.framework */; };
 		A1D0DCAC19504234004717F5 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1D0DCAB19504234004717F5 /* AVFoundation.framework */; };
 		A1FE60E81B7BFD9800C314ED /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1FE60E71B7BFD9800C314ED /* Security.framework */; };
+		C0F1F2511CD3C88000A849D1 /* decoder_alac_other.c in Sources */ = {isa = PBXBuildFile; fileRef = A1E9740E16DBAEAA000AD9E4 /* decoder_alac_other.c */; };
 		C80FE37F1C83F56D00E4A847 /* DeviceIDRetriver.m in Sources */ = {isa = PBXBuildFile; fileRef = C80FE37D1C83F56D00E4A847 /* DeviceIDRetriver.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		A1D0DC4E1950378A004717F5 /* CopyFiles */ = {
+		A1D0DC4E1950378A004717F5 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
 			);
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -93,7 +94,7 @@
 		A19E4AF116CA959700E5D60F /* audiooutput.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audiooutput.h; sourceTree = "<group>"; };
 		A19E4AF216CA959700E5D60F /* audiooutput_apple.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = audiooutput_apple.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		A19E4AF516CA959700E5D60F /* audioqueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = audioqueue.h; sourceTree = "<group>"; };
-		A19E4AF616CA959700E5D60F /* audioqueue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; lineEnding = 0; path = audioqueue.c; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
+		A19E4AF616CA959700E5D60F /* audioqueue.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; lineEnding = 0; path = audioqueue.c; sourceTree = "<group>"; };
 		A19E4B0B16CA95AC00E5D60F /* alac.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = alac.h; sourceTree = "<group>"; };
 		A19E4B0C16CA95AC00E5D60F /* alac.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = alac.c; sourceTree = "<group>"; };
 		A19E4B1016CA95C900E5D60F /* socket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = socket.h; sourceTree = "<group>"; };
@@ -120,7 +121,7 @@
 		A1CD9F2817076E6A0015CBBA /* webclientconnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = webclientconnection.h; sourceTree = "<group>"; };
 		A1CD9F2917076E720015CBBA /* webclientconnection.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = webclientconnection.c; sourceTree = "<group>"; };
 		A1CF856416F3C02B009114B2 /* libcrypto.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libcrypto.a; sourceTree = "<group>"; };
-		A1D0DC501950378A004717F5 /* libairfloat.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libairfloat.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1D0DC501950378A004717F5 /* liblibairfloat.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblibairfloat.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1D0DCAB19504234004717F5 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		A1D490BF16D4EB000082AFDD /* rtpsocket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = rtpsocket.c; sourceTree = "<group>"; };
 		A1D490C016D4EB000082AFDD /* rtpsocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = rtpsocket.h; sourceTree = "<group>"; };
@@ -166,7 +167,7 @@
 		4898F9EF13CDAAD1006EC97E /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				A1D0DC501950378A004717F5 /* libairfloat.a */,
+				A1D0DC501950378A004717F5 /* liblibairfloat.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -437,7 +438,7 @@
 			buildPhases = (
 				A1D0DC4C1950378A004717F5 /* Sources */,
 				A1D0DC4D1950378A004717F5 /* Frameworks */,
-				A1D0DC4E1950378A004717F5 /* CopyFiles */,
+				A1D0DC4E1950378A004717F5 /* Copy Files */,
 			);
 			buildRules = (
 			);
@@ -445,7 +446,7 @@
 			);
 			name = libairfloat;
 			productName = libairfloat;
-			productReference = A1D0DC501950378A004717F5 /* libairfloat.a */;
+			productReference = A1D0DC501950378A004717F5 /* liblibairfloat.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -454,7 +455,7 @@
 		4898F9E513CDAAD1006EC97E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0730;
 			};
 			buildConfigurationList = 4898F9E813CDAAD1006EC97E /* Build configuration list for PBXProject "libairfloat" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -480,7 +481,6 @@
 			files = (
 				A12364281B7C111100E1605D /* hex.c in Sources */,
 				A1D0DC951950383D004717F5 /* webtools.c in Sources */,
-				A1D0DC8B195037FD004717F5 /* decoder_alac_apple.c in Sources */,
 				A1D0DCA01950384F004717F5 /* rtprecorder.c in Sources */,
 				A1D0DC9019503833004717F5 /* socket.c in Sources */,
 				A1D0DCA11950384F004717F5 /* raopsession.c in Sources */,
@@ -494,6 +494,7 @@
 				C80FE37F1C83F56D00E4A847 /* DeviceIDRetriver.m in Sources */,
 				A1D0DC85195037EE004717F5 /* log.c in Sources */,
 				A1D0DC81195037EE004717F5 /* base64.c in Sources */,
+				C0F1F2511CD3C88000A849D1 /* decoder_alac_other.c in Sources */,
 				A1D0DC88195037EE004717F5 /* thread_posix.c in Sources */,
 				A1D0DC981950383D004717F5 /* webrequest.c in Sources */,
 				A1D0DC86195037EE004717F5 /* mutex_posix.c in Sources */,
@@ -521,24 +522,58 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = armv7;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(SDKROOT)/usr/lib/system",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-DDEBUG",
 					"-DALLOW_LOCALHOST",
 					"-DUSE_BSD_SOCKETS",
+					"-DALAC_SOFTWARE",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALID_ARCHS = "arm64 armv6 armv7 armv7s";
 			};
 			name = Debug;
 		};
@@ -546,17 +581,52 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = armv7;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(SDKROOT)/usr/lib/system",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-DUSE_BSD_SOCKETS";
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 armv6 armv7 armv7s";
 			};
 			name = Release;
 		};
@@ -564,21 +634,56 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = armv7;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(SDKROOT)/usr/lib/system",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-DLOG_SERVER",
 					"-DALLOW_LOCALHOST",
 					"-DUSE_BSD_SOCKETS",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 armv6 armv7 armv7s";
 			};
 			name = "Release (Server Logs)";
 		};
@@ -586,24 +691,58 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = armv7;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(SDKROOT)/usr/lib/system",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-DDEBUG",
 					"-DLOG_SERVER",
 					"-DALLOW_LOCALHOST",
 					"-DUSE_BSD_SOCKETS",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALID_ARCHS = "arm64 armv6 armv7 armv7s";
 			};
 			name = "Debug (Server Logs)";
 		};
@@ -611,16 +750,51 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = armv7;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(SDKROOT)/usr/lib/system",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 armv6 armv7 armv7s";
 			};
 			name = "App Store Distribution";
 		};
@@ -628,321 +802,100 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = armv7;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(SDKROOT)/usr/lib/system",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALIDATE_PRODUCT = YES;
+				VALID_ARCHS = "arm64 armv6 armv7 armv7s";
 			};
 			name = "Ad Hoc Distribution";
 		};
 		A1D0DC711950378A004717F5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DSTROOT = /tmp/airfloat.dst;
-				ENABLE_BITCODE = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-					"$(SDKROOT)/usr/lib/system",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = Debug;
 		};
 		A1D0DC721950378A004717F5 /* Debug (Server Logs) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DSTROOT = /tmp/airfloat.dst;
-				ENABLE_BITCODE = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-					"$(SDKROOT)/usr/lib/system",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = "Debug (Server Logs)";
 		};
 		A1D0DC731950378A004717F5 /* Debug (Server Logs - ALAC Software) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DSTROOT = /tmp/airfloat.dst;
-				ENABLE_BITCODE = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-					"$(SDKROOT)/usr/lib/system",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 			};
 			name = "Debug (Server Logs - ALAC Software)";
 		};
 		A1D0DC741950378A004717F5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DSTROOT = /tmp/airfloat.dst;
-				ENABLE_BITCODE = NO;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-					"$(SDKROOT)/usr/lib/system",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
-				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
 		A1D0DC751950378A004717F5 /* Release (Server Logs) */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DSTROOT = /tmp/airfloat.dst;
-				ENABLE_BITCODE = NO;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-					"$(SDKROOT)/usr/lib/system",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
-				VALIDATE_PRODUCT = YES;
 			};
 			name = "Release (Server Logs)";
 		};
 		A1D0DC761950378A004717F5 /* App Store Distribution */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DSTROOT = /tmp/airfloat.dst;
-				ENABLE_BITCODE = NO;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-					"$(SDKROOT)/usr/lib/system",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
-				VALIDATE_PRODUCT = YES;
 			};
 			name = "App Store Distribution";
 		};
 		A1D0DC771950378A004717F5 /* Ad Hoc Distribution */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				DSTROOT = /tmp/airfloat.dst;
-				ENABLE_BITCODE = NO;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-					"$(SRCROOT)",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-					"$(SDKROOT)/usr/lib/system",
-				);
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
-				VALIDATE_PRODUCT = YES;
 			};
 			name = "Ad Hoc Distribution";
 		};
@@ -950,24 +903,58 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = armv7;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
 				GCC_VERSION = "";
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = NO;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 4.2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(SDKROOT)/usr/lib/system",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-DDEBUG",
 					"-DLOG_SERVER",
 					"-DALAC_SOFTWARE",
 					"-DUSE_BSD_SOCKETS",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				VALID_ARCHS = "arm64 armv6 armv7 armv7s";
 			};
 			name = "Debug (Server Logs - ALAC Software)";
 		};

--- a/libairfloat/libairfloat/audiooutput.h
+++ b/libairfloat/libairfloat/audiooutput.h
@@ -40,4 +40,6 @@ typedef struct audio_output_t *audio_output_p;
 void audio_output_set_volume(audio_output_p ao, double volume);
 void audio_output_set_muted(audio_output_p ao, bool muted);
 
+void audio_output_session_start();
+void audio_output_session_stop();
 #endif

--- a/libairfloat/libairfloat/audioqueue.c
+++ b/libairfloat/libairfloat/audioqueue.c
@@ -42,7 +42,8 @@
 #include "audiooutput.h"
 #include "audioqueue.h"
 
-#define MAX_QUEUE_COUNT 500
+//#define MAX_QUEUE_COUNT 500
+#define MAX_QUEUE_COUNT 4096
 #define CLIENT_SERVER_DIFFERENCE_BACKLOG 10
 #define LOOP_FROM(x, y, d, c) for (struct audio_packet_t* x = y ; x != c ; x = x->d)
 #define IS_UPPER(x) (((x % 0xFFFF) & 0x8000) != 0)


### PR DESCRIPTION
This PR adds "keep-alive", meaning that AirFloat will stay active and ready for connections even when no RAOP clients are connected (and no stream is playing back currently). To increase visibility of this feature, i also added local notifications (via UILocalNotification), triggered when the app is backgrounded and an active stream is disconnected. The work is based on loretoparisis' recommendations (http://stackoverflow.com/a/16068213).

Regarding the underlying libairfloat library, i exposed the start/stop methods of the shared AVAudioSession instance (audiooutput_apple.m). This in turn enables AirFloat to register its AudioSession on didFinishLaunchingWithOptions, as per Apples recommendations for apps using AVFoundation.

I also increased the libairfloat audio queue size from 500 to 4096 (audioqueue.c). This change increased the stability of the connection considerably within my test setups, but should be tested further.

Thanks for really great application and library.